### PR TITLE
🚀 [feature] 카카오 소셜 로그인 구현 및 추가 회원정보 기입 API 구현

### DIFF
--- a/src/main/java/com/example/tikicktaka/config/ClientConfig.java
+++ b/src/main/java/com/example/tikicktaka/config/ClientConfig.java
@@ -1,0 +1,13 @@
+package com.example.tikicktaka.config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class ClientConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/example/tikicktaka/config/springSecurity/utils/JwtUtil.java
+++ b/src/main/java/com/example/tikicktaka/config/springSecurity/utils/JwtUtil.java
@@ -2,13 +2,14 @@ package com.example.tikicktaka.config.springSecurity.utils;
 
 import com.example.tikicktaka.config.springSecurity.constants.SecurityConstants;
 import io.jsonwebtoken.Jwts;
+import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.List;
-
+@Component
 public class JwtUtil {
 
     private static SecretKey secretKey;

--- a/src/main/java/com/example/tikicktaka/converter/member/MemberConverter.java
+++ b/src/main/java/com/example/tikicktaka/converter/member/MemberConverter.java
@@ -89,4 +89,12 @@ public class MemberConverter {
                 .checkEmail(checkEmail)
                 .build();
     }
+
+    public static MemberResponseDTO.CompleteSignupResultDTO toCompleteSignupResultDTO(Member member) {
+        return new MemberResponseDTO.CompleteSignupResultDTO(
+                member.getId(),
+                member.getName(),
+                member.getEmail()
+        );
+    }
 }

--- a/src/main/java/com/example/tikicktaka/domain/member/Member.java
+++ b/src/main/java/com/example/tikicktaka/domain/member/Member.java
@@ -31,6 +31,7 @@ public class Member extends BaseDateTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, columnDefinition = "VARCHAR(10)")
+    @ColumnDefault("'member'")
     private MemberRole memberRole;
 
     @Column(columnDefinition = "VARCHAR(50)")
@@ -84,4 +85,24 @@ public class Member extends BaseDateTimeEntity {
     public void setMemberStatus(MemberStatus memberStatus) { this.memberStatus = memberStatus; }
 
     public void setSocialType(SocialType socialType) { this.socialType = socialType; }
+
+
+    public Member(String email, String nickname, String name, Date birthday, Gender gender, String phone, List<MemberTerm> memberTermList) {
+
+    }
+    public Member(String email, String nickname, List<MemberTerm> memberTermList) {
+
+    }
+
+    // Method to update additional information after social login
+    public void updateAdditionalInfo(String name, Date birthday, Gender gender, String phone, List<MemberTerm> memberTermList) {
+        this.name = name;
+        this.birthday = birthday;
+        this.gender = gender;
+        this.phone = phone;
+        this.memberTermList = memberTermList;
+        this.memberStatus = MemberStatus.ACTIVE;
+    }
+
+
 }

--- a/src/main/java/com/example/tikicktaka/domain/oauth/OAuthApiClient.java
+++ b/src/main/java/com/example/tikicktaka/domain/oauth/OAuthApiClient.java
@@ -1,0 +1,9 @@
+package com.example.tikicktaka.domain.oauth;
+
+import com.example.tikicktaka.domain.enums.SocialType;
+
+public interface OAuthApiClient {
+    SocialType socialType();
+    String requestAccessToken(OAuthLoginParams params);
+    OAuthInfoResponse requestOauthInfo(String accessToken);
+}

--- a/src/main/java/com/example/tikicktaka/domain/oauth/OAuthInfoResponse.java
+++ b/src/main/java/com/example/tikicktaka/domain/oauth/OAuthInfoResponse.java
@@ -1,0 +1,9 @@
+package com.example.tikicktaka.domain.oauth;
+
+import com.example.tikicktaka.domain.enums.SocialType;
+
+public interface OAuthInfoResponse {
+    String getEmail();
+    String getNickname();
+    SocialType getSocialType();
+}

--- a/src/main/java/com/example/tikicktaka/domain/oauth/OAuthLoginParams.java
+++ b/src/main/java/com/example/tikicktaka/domain/oauth/OAuthLoginParams.java
@@ -1,0 +1,8 @@
+package com.example.tikicktaka.domain.oauth;
+import com.example.tikicktaka.domain.enums.SocialType;
+import org.springframework.util.MultiValueMap;
+
+public interface OAuthLoginParams {
+    SocialType socialType();
+    MultiValueMap<String,String> makeBody();
+}

--- a/src/main/java/com/example/tikicktaka/domain/oauth/RequestOAuthInfoService.java
+++ b/src/main/java/com/example/tikicktaka/domain/oauth/RequestOAuthInfoService.java
@@ -1,0 +1,26 @@
+package com.example.tikicktaka.domain.oauth;
+import com.example.tikicktaka.domain.enums.SocialType;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class RequestOAuthInfoService {
+    private final Map<SocialType, OAuthApiClient> clients;
+
+    public RequestOAuthInfoService(List<OAuthApiClient> clients) {
+        this.clients = clients.stream().collect(
+                Collectors.toUnmodifiableMap(OAuthApiClient::socialType, Function.identity())
+        );
+    }
+
+    public OAuthInfoResponse request(OAuthLoginParams params) {
+        OAuthApiClient client = clients.get(params.socialType());
+        String accessToken = client.requestAccessToken(params);
+        return client.requestOauthInfo(accessToken);
+    }
+}

--- a/src/main/java/com/example/tikicktaka/infra/kakao/KakaoApiClient.java
+++ b/src/main/java/com/example/tikicktaka/infra/kakao/KakaoApiClient.java
@@ -1,0 +1,75 @@
+package com.example.tikicktaka.infra.kakao;
+
+import com.example.tikicktaka.domain.enums.SocialType;
+import com.example.tikicktaka.domain.oauth.OAuthApiClient;
+import com.example.tikicktaka.domain.oauth.OAuthInfoResponse;
+import com.example.tikicktaka.domain.oauth.OAuthLoginParams;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+//@Component
+@Service
+@RequiredArgsConstructor
+public class KakaoApiClient implements OAuthApiClient {
+
+    private static final String GRANT_TYPE = "authorization_code";
+
+    @Value("${oauth.kakao.url.auth}")
+    private String authUrl;
+
+    @Value("${oauth.kakao.url.api}")
+    private String apiUrl;
+
+    @Value("${oauth.kakao.client-id}")
+    private String clientId;
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    public SocialType socialType() {
+        return SocialType.KAKAO;
+    }
+
+    @Override
+    public String requestAccessToken(OAuthLoginParams params) {
+        String url = authUrl + "/oauth/token";
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = params.makeBody();
+        body.add("grant_type", GRANT_TYPE);
+        body.add("client_id", clientId);
+
+        HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
+
+        KakaoTokens response = restTemplate.postForObject(url, request, KakaoTokens.class);
+
+        assert response != null;
+        return response.getAccessToken();
+    }
+
+    @Override
+    public OAuthInfoResponse requestOauthInfo(String accessToken) {
+        String url = apiUrl + "/v2/user/me";
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        httpHeaders.set("Authorization", "Bearer " + accessToken);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("property_keys", "[\"kakao_account.email\", \"kakao_account.profile\"]");
+
+        HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
+
+        return restTemplate.postForObject(url, request, KakaoInfoResponse.class);
+    }
+}

--- a/src/main/java/com/example/tikicktaka/infra/kakao/KakaoInfoResponse.java
+++ b/src/main/java/com/example/tikicktaka/infra/kakao/KakaoInfoResponse.java
@@ -1,0 +1,44 @@
+package com.example.tikicktaka.infra.kakao;
+
+import com.example.tikicktaka.domain.enums.SocialType;
+import com.example.tikicktaka.domain.enums.SocialType;
+import com.example.tikicktaka.domain.oauth.OAuthInfoResponse;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoInfoResponse implements OAuthInfoResponse {
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class KakaoAccount {
+        private KakaoProfile profile;
+        private String email;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class KakaoProfile {
+        private String nickname;
+    }
+
+    @Override
+    public String getEmail() {
+        return kakaoAccount.email;
+    }
+
+    @Override
+    public String getNickname() {
+        return kakaoAccount.profile.nickname;
+    }
+
+    @Override
+    public SocialType getSocialType() {
+        return SocialType.KAKAO;
+    }
+}

--- a/src/main/java/com/example/tikicktaka/infra/kakao/KakaoLoginParams.java
+++ b/src/main/java/com/example/tikicktaka/infra/kakao/KakaoLoginParams.java
@@ -1,0 +1,25 @@
+package com.example.tikicktaka.infra.kakao;
+import com.example.tikicktaka.domain.enums.SocialType;
+import com.example.tikicktaka.domain.oauth.OAuthLoginParams;
+import com.example.tikicktaka.domain.enums.SocialType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@Getter
+@NoArgsConstructor
+public class KakaoLoginParams implements OAuthLoginParams {
+    private String authorizationCode;
+
+    public SocialType socialType(){
+        return SocialType.KAKAO;
+    }
+
+    @Override
+    public MultiValueMap<String, String> makeBody() {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code",authorizationCode);
+        return body;
+    }
+}

--- a/src/main/java/com/example/tikicktaka/infra/kakao/KakaoTokens.java
+++ b/src/main/java/com/example/tikicktaka/infra/kakao/KakaoTokens.java
@@ -1,0 +1,29 @@
+package com.example.tikicktaka.infra.kakao;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokens {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private String expiresIn;
+
+    @JsonProperty("refresh_token_expires_in")
+    private String refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+}

--- a/src/main/java/com/example/tikicktaka/service/OAuthService/OAuthLoginService.java
+++ b/src/main/java/com/example/tikicktaka/service/OAuthService/OAuthLoginService.java
@@ -1,0 +1,56 @@
+package com.example.tikicktaka.service.OAuthService;
+
+import com.example.tikicktaka.config.springSecurity.utils.JwtUtil;
+import com.example.tikicktaka.domain.oauth.OAuthInfoResponse;
+import com.example.tikicktaka.domain.oauth.RequestOAuthInfoService;
+import com.example.tikicktaka.infra.kakao.KakaoLoginParams;
+import com.example.tikicktaka.domain.member.Member;
+import com.example.tikicktaka.domain.enums.MemberRole;
+import com.example.tikicktaka.repository.member.MemberRepository;
+import com.example.tikicktaka.web.dto.member.MemberResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class OAuthLoginService {
+
+    private final MemberRepository memberRepository;
+    private final RequestOAuthInfoService requestOAuthInfoService;
+    private final JwtUtil jwtUtil; // JWT 유틸리티 추가
+    @Value("${JWT_TOKEN_SECRET}")
+    private String key;
+
+    private int expiredMs = 1000 * 60 * 60 * 24 * 5;
+
+    public MemberResponseDTO.MemberLoginResponseDTO login(KakaoLoginParams params) {
+        OAuthInfoResponse oAuthInfoResponse = requestOAuthInfoService.request(params);
+        Long memberId = findOrCreateMember(oAuthInfoResponse);
+
+        Member member = memberRepository.findByEmail(oAuthInfoResponse.getEmail()).orElseThrow(()-> new IllegalArgumentException("Member not found"));
+
+        String jwt = jwtUtil.createJwt(member.getId(), member.getNickname(), expiredMs, key, List.of("MEMBER"));
+        return new MemberResponseDTO.MemberLoginResponseDTO(memberId, member.getEmail(), member.getNickname(),jwt);
+    }
+
+    private Long findOrCreateMember(OAuthInfoResponse oAuthInfoResponse) {
+        return memberRepository.findByEmail(oAuthInfoResponse.getEmail())
+                .map(Member::getId)
+                .orElseGet(() -> newMember(oAuthInfoResponse));
+    }
+
+    private Long newMember(OAuthInfoResponse oAuthInfoResponse) {
+        Member member = Member.builder()
+                .email(oAuthInfoResponse.getEmail())
+                .nickname(oAuthInfoResponse.getNickname())
+                .socialType(oAuthInfoResponse.getSocialType())
+                .memberRole(MemberRole.MEMBER) // 기본 롤 설정
+                .build();
+
+        return memberRepository.save(member).getId();
+    }
+}

--- a/src/main/java/com/example/tikicktaka/service/memberService/MemberCommandService.java
+++ b/src/main/java/com/example/tikicktaka/service/memberService/MemberCommandService.java
@@ -3,6 +3,7 @@ package com.example.tikicktaka.service.memberService;
 import com.example.tikicktaka.domain.member.Auth;
 import com.example.tikicktaka.domain.member.Member;
 import com.example.tikicktaka.web.dto.member.MemberRequestDTO;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface MemberCommandService {
 
@@ -17,4 +18,7 @@ public interface MemberCommandService {
     Auth sendEmailAuth(String email);
 
     Boolean confirmEmailAuth(MemberRequestDTO.EmailAuthConfirmDTO request);
+
+    @Transactional
+    Member completeSignup(Long memberId, MemberRequestDTO.CompleteSignupDTO request);
 }

--- a/src/main/java/com/example/tikicktaka/service/memberService/MemberCommandServiceImpl.java
+++ b/src/main/java/com/example/tikicktaka/service/memberService/MemberCommandServiceImpl.java
@@ -180,4 +180,33 @@ public class MemberCommandServiceImpl implements MemberCommandService{
 
         return checkEmail;
     }
+
+
+    @Transactional
+    @Override
+    public Member completeSignup(Long memberId, MemberRequestDTO.CompleteSignupDTO request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // Convert request terms to MemberTerm entities
+        HashMap<Term, Boolean> termMap = new HashMap<>();
+        for (int i = 0; i < request.getMemberTerm().size(); i++) {
+            termMap.put(termRepository.findById(i + 1L)
+                    .orElseThrow(() -> new MemberHandler(ErrorStatus.TERM_NOT_FOUND)), request.getMemberTerm().get(i));
+        }
+
+        List<MemberTerm> memberTermList = MemberConverter.toMemberTermList(termMap);
+
+        // Update member with additional info
+        member.updateAdditionalInfo(
+                request.getName(),
+                request.getBirthday(),
+                request.getGender(),
+                request.getPhone(),
+                memberTermList
+        );
+
+
+        return memberRepository.save(member);
+    }
 }

--- a/src/main/java/com/example/tikicktaka/web/controller/AuthController.java
+++ b/src/main/java/com/example/tikicktaka/web/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.example.tikicktaka.web.controller;
+
+import com.example.tikicktaka.infra.kakao.KakaoLoginParams;
+import com.example.tikicktaka.service.OAuthService.OAuthLoginService;
+import com.example.tikicktaka.web.dto.member.MemberResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+    private final OAuthLoginService oAuthLoginService;
+
+//    @PostMapping("/kakao")
+//    public ResponseEntity<MemberResponseDTO.KakaoLoginResultDTO> loginKakao(@RequestBody KakaoLoginParams params) {
+//        MemberResponseDTO.KakaoLoginResultDTO result = oAuthLoginService.login(params);
+//        return ResponseEntity.ok(result);
+//    }
+
+    @PostMapping("/kakao")
+    public ResponseEntity<MemberResponseDTO.MemberLoginResponseDTO> loginKakao(@RequestBody KakaoLoginParams params) {
+        MemberResponseDTO.MemberLoginResponseDTO response = oAuthLoginService.login(params);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/tikicktaka/web/controller/MemberController.java
+++ b/src/main/java/com/example/tikicktaka/web/controller/MemberController.java
@@ -19,10 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Slf4j
@@ -94,4 +91,11 @@ public class MemberController {
         return ResponseEntity.ok().body(member.getEmail());
     }
 
+    //소셜 로그인 후 회원가입
+    @PostMapping("/complete-signup/{memberId}")
+    @Operation(summary = "추가 정보 입력 API", description = "소셜 로그인 후 추가 정보 입력을 처리합니다.")
+    public ApiResponse<MemberResponseDTO.CompleteSignupResultDTO> completeSignup(@PathVariable Long memberId, @RequestBody @Valid MemberRequestDTO.CompleteSignupDTO request) {
+        Member member = memberCommandService.completeSignup(memberId, request);
+        return ApiResponse.onSuccess(MemberConverter.toCompleteSignupResultDTO(member));
+    }
 }

--- a/src/main/java/com/example/tikicktaka/web/dto/member/MemberRequestDTO.java
+++ b/src/main/java/com/example/tikicktaka/web/dto/member/MemberRequestDTO.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.Date;
 import java.util.List;
@@ -78,4 +79,24 @@ public class MemberRequestDTO {
         private String email;
         private String code;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CompleteSignupDTO{
+
+        @NotBlank(message = "이름을 입력해주세요.")
+        private String name;
+
+        private Date birthday;
+
+        @NotBlank(message = "휴대폰 번호를 입력해주세요")
+        private String phone;
+
+        private Gender gender;
+
+        private List<Boolean> memberTerm;
+    }
+
 }

--- a/src/main/java/com/example/tikicktaka/web/dto/member/MemberResponseDTO.java
+++ b/src/main/java/com/example/tikicktaka/web/dto/member/MemberResponseDTO.java
@@ -61,4 +61,23 @@ public class MemberResponseDTO {
     public static class EmailAuthConfirmResultDTO{
         Boolean checkEmail;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CompleteSignupResultDTO {
+        private Long id;
+        private String name;
+        private String email;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberLoginResponseDTO {
+        private Long memberId;
+        private String nickname;
+        private String email;
+        private String jwt;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,9 +32,16 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: update
+          auto: create
         default_batch_fetch_size: 1000
 
 jwt:
   token:
     secret: ${JWT_TOKEN_SECRET}
+
+oauth:
+  kakao:
+    client-id: ${CLIENT_ID}
+    url:
+      auth: https://kauth.kakao.com
+      api: https://kapi.kakao.com


### PR DESCRIPTION
# 🚀 개요
카카오 소셜 로그인 API 및 추가 회원정보 저장 API 구현

## 🔍 변경사항
카카오 소셜 로그인 API 및 추가 회원정보 저장 API 구현


## ⏳ 작업 내용
카카오 소셜 로그인 API 및 추가 회원정보 저장 API 구현


### 📝 논의사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나, 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
규혁님이 그 전에 개발해두셨던 코드에서 수정사항이 꽤 있어서 확인 부탁드립니다
